### PR TITLE
Export aurURL

### DIFF
--- a/aur.go
+++ b/aur.go
@@ -7,7 +7,8 @@ import (
 	"net/url"
 )
 
-const aurURL = "https://aur.archlinux.org/rpc.php?"
+//AurURL is the base string from which the query is built
+var AurURL = "https://aur.archlinux.org/rpc.php?"
 
 type response struct {
 	Error       string `json:"error"`
@@ -46,7 +47,7 @@ type Pkg struct {
 
 func get(values url.Values) ([]Pkg, error) {
 	values.Set("v", "5")
-	resp, err := http.Get(aurURL + values.Encode())
+	resp, err := http.Get(AurURL + values.Encode())
 	if err != nil {
 		return nil, err
 	}

--- a/aur.go
+++ b/aur.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 )
 
-//AurURL is the base string from which the query is built
-var AurURL = "https://aur.archlinux.org/rpc.php?"
+//AURURL is the base string from which the query is built
+var AURURL = "https://aur.archlinux.org/rpc.php?"
 
 type response struct {
 	Error       string `json:"error"`
@@ -47,7 +47,7 @@ type Pkg struct {
 
 func get(values url.Values) ([]Pkg, error) {
 	values.Set("v", "5")
-	resp, err := http.Get(AurURL + values.Encode())
+	resp, err := http.Get(AURURL + values.Encode())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hey @mikkeloscar would it be possible to export aurURL for testing purposes? 
I want to point `yay` to another `aur` instance for testing without having to pull out -ldflags, would this be ok with you?

Also could be useful for users in east asia who have mirrors of the aur closer to them
I ran the tests with `AurURL = https://aur.tuna.tsinghua.edu.cn/rpc.php?` 
```
ok      github.com/jguer/aur    59.983s
```