### PR TITLE
Create error via errors.New

### DIFF
--- a/aur.go
+++ b/aur.go
@@ -2,7 +2,7 @@ package aur
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"net/http"
 	"net/url"
 )
@@ -62,7 +62,7 @@ func get(values url.Values) ([]Pkg, error) {
 	}
 
 	if len(result.Error) > 0 {
-		return nil, fmt.Errorf(result.Error)
+		return nil, errors.New(result.Error)
 	}
 
 	return result.Results, nil


### PR DESCRIPTION
fmt.Printf expects a format string as the first argument. As we do not
control the error it is possible, albeit very unlikley, that the error
message could contain a '%' and break the string.