### PR TITLE
support all &by= fields the RPC supports

### DIFF
--- a/aur.go
+++ b/aur.go
@@ -68,33 +68,62 @@ func get(values url.Values) ([]Pkg, error) {
 	return result.Results, nil
 }
 
-// Search searches for packages by package name.
-func Search(query string) ([]Pkg, error) {
+func searchBy(query, by string) ([]Pkg, error) {
 	v := url.Values{}
 	v.Set("type", "search")
 	v.Set("arg", query)
 
+	if by != "" {
+		v.Set("by", by)
+	}
+
 	return get(v)
+}
+
+// Search searches for packages by the RPC's default defautl field.
+// This is the same as SearchByNameDesc
+func Search(query string) ([]Pkg, error) {
+	return searchBy(query, "")
+}
+
+// Search searches for packages by package name.
+func SearchByName(query string) ([]Pkg, error) {
+	return searchBy(query, "name")
 }
 
 // SearchByNameDesc searches for package by package name and description.
 func SearchByNameDesc(query string) ([]Pkg, error) {
-	v := url.Values{}
-	v.Set("type", "search")
-	v.Set("by", "name-desc")
-	v.Set("arg", query)
-
-	return get(v)
+	return searchBy(query, "name-desc")
 }
 
 // SearchByMaintainer searches for package by maintainer.
 func SearchByMaintainer(query string) ([]Pkg, error) {
-	v := url.Values{}
-	v.Set("type", "search")
-	v.Set("by", "maintainer")
-	v.Set("arg", query)
+	return searchBy(query, "maintainer")
+}
 
-	return get(v)
+// SearchByDepends searches for packages that depend on query
+func SearchByDepends(query string) ([]Pkg, error) {
+	return searchBy(query, "depends")
+}
+
+// SearchByMakeDepends searches for packages that makedepend on query
+func SearchByMakeDepends(query string) ([]Pkg, error) {
+	return searchBy(query, "makedepends")
+}
+
+// SearchByOptDepends searches for packages that optdepend on query
+func SearchByOptDepends(query string) ([]Pkg, error) {
+	return searchBy(query, "optdepends")
+}
+
+// SearchByCheckDepends searches for packages that checkdepend on query
+func SearchByCheckDepends(query string) ([]Pkg, error) {
+	return searchBy(query, "checkdepends")
+}
+
+// Orphans returns all orphan packages in the AUR.
+func Orphans() ([]Pkg, error) {
+	return SearchByMaintainer("")
 }
 
 // Info shows info for one or multiple packages.

--- a/aur_test.go
+++ b/aur_test.go
@@ -2,57 +2,24 @@ package aur
 
 import "testing"
 
-// TestSearch test searching for packages by name and/or description
-func TestSearch(t *testing.T) {
-	rs, err := Search("linux")
+func expectPackages(t *testing.T, n int, rs []Pkg, err error) {
 	if err != nil {
 		t.Error(err)
 	}
 
-	if len(rs) < 100 {
-		t.Errorf("Expected more than 100 packages, got '%d'", len(rs))
+	if len(rs) < n {
+		t.Errorf("Expected more than %d packages, got '%d'", n, len(rs))
 	}
+}
 
-	rs, err = Search("li")
+
+func expectTooMany(t *testing.T, rs []Pkg, err error) {
 	if err.Error() != "Too many package results." {
 		t.Errorf("Expected error 'Too many package results.', got '%s'", err.Error())
 	}
 
 	if len(rs) > 0 {
 		t.Errorf("Expected no results, got '%d'", len(rs))
-	}
-}
-
-// TestSearchByNameDesc test searching for packages package name and desc.
-func TestSearchByNameDesc(t *testing.T) {
-	rs, err := SearchByNameDesc("linux")
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(rs) < 100 {
-		t.Errorf("Expected more than 100 packages, got '%d'", len(rs))
-	}
-
-	rs, err = Search("li")
-	if err.Error() != "Too many package results." {
-		t.Errorf("Expected error 'Too many package results.', got '%s'", err.Error())
-	}
-
-	if len(rs) > 0 {
-		t.Errorf("Expected no results, got '%d'", len(rs))
-	}
-}
-
-// TestSearchByMaintainer test searching for packages by maintainer
-func TestSearchByMaintainer(t *testing.T) {
-	rs, err := SearchByMaintainer("moscar")
-	if err != nil {
-		t.Error(err)
-	}
-
-	if len(rs) < 3 {
-		t.Errorf("Expected more than 3 packages, got '%d'", len(rs))
 	}
 }
 
@@ -66,4 +33,61 @@ func TestInfo(t *testing.T) {
 	if len(rs) != 2 {
 		t.Errorf("Expected two packages, got %d", len(rs))
 	}
+}
+
+// TestSearch test searching for packages by the AUR's default by field
+func TestSearch(t *testing.T) {
+	rs, err := Search("linux")
+	expectPackages(t, 100, rs, err)
+
+	rs, err = Search("li")
+	expectTooMany(t, rs, err)
+}
+
+// TestSearchByName test searching for packages by package name
+func TestSearchByName(t *testing.T) {
+	rs, err := SearchByNameDesc("linux")
+	expectPackages(t, 100, rs, err)
+}
+
+// TestSearchByNameDesc test searching for packages package name and desc.
+func TestSearchByNameDesc(t *testing.T) {
+	rs, err := SearchByNameDesc("linux")
+	expectPackages(t, 100, rs, err)
+}
+
+// TestSearchByMaintainer test searching for packages by maintainer
+func TestSearchByMaintainer(t *testing.T) {
+	rs, err := SearchByMaintainer("moscar")
+	expectPackages(t, 3, rs, err)
+}
+
+// TestOrphans test searching for orphans
+func TestOrphans(t *testing.T) {
+	rs, err := Orphans()
+	expectPackages(t, 500, rs, err)
+}
+
+// TestSearchByDepends test searching for packages by depends
+func TestSearchByDepends(t *testing.T) {
+	rs, err := SearchByDepends("python")
+	expectPackages(t, 100, rs, err)
+}
+
+// TestSearchByMakeDepends test searching for packages by makedepends
+func TestSearchByMakeDepends(t *testing.T) {
+	rs, err := SearchByMakeDepends("python")
+	expectPackages(t, 100, rs, err)
+}
+
+// TestSearchByOptDepends test searching for packages by optdepends
+func TestSearchByOptDepends(t *testing.T) {
+	rs, err := SearchByOptDepends("python")
+	expectPackages(t, 100, rs, err)
+}
+
+// TestSearchByCheckDepends test searching for packages by checkdepends
+func TestSearchByCheckDepends(t *testing.T) {
+	rs, err := SearchByCheckDepends("python")
+	expectPackages(t, 10, rs, err)
 }


### PR DESCRIPTION
Adds function for all of the possible &by= keywords as documented here https://wiki.archlinux.org/index.php/Aurweb_RPC_interface. And refactor
away the common code.

Also add `Orphans()` as a convenience for `SearchByMaintainer("")`.