### PR TITLE
Add AUR is unavailable as a response to status code 503

### DIFF
--- a/aur.go
+++ b/aur.go
@@ -86,6 +86,11 @@ func get(values url.Values) ([]Pkg, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if resp.StatusCode == 503 {
+		return nil, errors.New("AUR is unavailable at this moment")
+	}
+
 	defer resp.Body.Close()
 
 	dec := json.NewDecoder(resp.Body)


### PR DESCRIPTION
Aurweb was returning status code `503` for maintenance for a while on 27/07/2019 and not delivering the expect json results

http.Get's error response is the following:
```
 An error is returned if there were too many redirects or if there was an HTTP protocol error. A non-2xx response doesn't cause an error. Any returned error will be of type *url.Error. The url.Error value's Timeout method will report true if request timed out or was canceled. 
```
Therefore parsing continued and errored later. This pull requests adds an early escape and a domain specific description to the error.

A valid response includes status code 200 or 304 (content unmodified) but I avoided making a generalization on the returned status code.

EDIT: Sources of possible status codes:
https://git.archlinux.org/aurweb.git/tree/web/html/rpc.php - 405 if it's not a GET request
https://git.archlinux.org/aurweb.git/tree/web/lib/aurjson.class.php#n125 - 304 Not Modified