### PR TITLE
Improve error handling by HTTP status code

### DIFF
--- a/aur.go
+++ b/aur.go
@@ -10,6 +10,11 @@ import (
 //AURURL is the base string from which the query is built
 var AURURL = "https://aur.archlinux.org/rpc.php?"
 
+var (
+	// ErrServiceUnavailable represents a error when AUR is unavailable
+	ErrServiceUnavailable = errors.New("AUR is unavailable at this moment")
+)
+
 type response struct {
 	Error       string `json:"error"`
 	Version     int    `json:"version"`
@@ -86,12 +91,11 @@ func get(values url.Values) ([]Pkg, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	if resp.StatusCode == http.StatusServiceUnavailable {
-		return nil, errors.New("AUR is unavailable at this moment")
-	}
-
 	defer resp.Body.Close()
+
+	if err := getErrorByStatusCode(resp.StatusCode); err != nil {
+		return nil, err
+	}
 
 	dec := json.NewDecoder(resp.Body)
 	result := new(response)
@@ -117,6 +121,16 @@ func searchBy(query, by string) ([]Pkg, error) {
 	}
 
 	return get(v)
+}
+
+func getErrorByStatusCode(code int) error {
+	switch code {
+	case http.StatusBadGateway, http.StatusGatewayTimeout:
+		return ErrServiceUnavailable
+	case http.StatusServiceUnavailable:
+		return ErrServiceUnavailable
+	}
+	return nil
 }
 
 // Search searches for packages using the RPC's default search by.

--- a/aur_test.go
+++ b/aur_test.go
@@ -1,6 +1,9 @@
 package aur
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+)
 
 func expectPackages(t *testing.T, n int, rs []Pkg, err error) {
 	if err != nil {
@@ -19,6 +22,12 @@ func expectTooMany(t *testing.T, rs []Pkg, err error) {
 
 	if len(rs) > 0 {
 		t.Errorf("Expected no results, got '%d'", len(rs))
+	}
+}
+
+func expectError(t *testing.T, expected error, actual error) {
+	if expected != actual {
+		t.Errorf(`Expected error is "%s", but actual "%s"`, expected, actual)
 	}
 }
 
@@ -90,4 +99,11 @@ func TestSearchByOptDepends(t *testing.T) {
 func TestSearchByCheckDepends(t *testing.T) {
 	rs, err := SearchBy("python", CheckDepends)
 	expectPackages(t, 10, rs, err)
+}
+
+// TestGetErrorByStatusCode test get error by HTTP status code
+func TestGetErrorByStatusCode(t *testing.T) {
+	expectError(t, ErrServiceUnavailable, getErrorByStatusCode(http.StatusBadGateway))
+	expectError(t, ErrServiceUnavailable, getErrorByStatusCode(http.StatusGatewayTimeout))
+	expectError(t, ErrServiceUnavailable, getErrorByStatusCode(http.StatusServiceUnavailable))
 }


### PR DESCRIPTION
AUR was returned status code `502` for a short time on 2019/12/16.
(see https://bugs.archlinux.org/task/64851#comment184573)

This package has returned the following json parse error while until AUR has been back.

```
invalid character '<' looking for beginning of value
```

The PR is adds getErrorByStatusCode function for returns a error by HTTP status code.

The function will be return service unavailable error only if status code is `502` or `503` or `504`. `504` is a error about gateway like `502`.