### PR TITLE
Add configurable client

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,20 +1,16 @@
 name: Go
 on: [push]
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ["^1.16", "1.14", "1.13"]
     steps:
-
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.13
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-
-    - name: Test
-      run: go test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Test
+        run: go test ./...

--- a/aur.go
+++ b/aur.go
@@ -7,23 +7,15 @@ import (
 	"net/url"
 )
 
-//AURURL is the base string from which the query is built
+// AURURL is the base string from which the query is built.
 var AURURL = "https://aur.archlinux.org/rpc.php?"
 
 var (
-	// ErrServiceUnavailable represents a error when AUR is unavailable
+	// ErrServiceUnavailable represents a error when AUR is unavailable.
 	ErrServiceUnavailable = errors.New("AUR is unavailable at this moment")
 )
 
-type response struct {
-	Error       string `json:"error"`
-	Version     int    `json:"version"`
-	Type        string `json:"type"`
-	ResultCount int    `json:"resultcount"`
-	Results     []Pkg  `json:"results"`
-}
-
-//By specifies what to seach by in RPC searches
+// By specifies what to seach by in RPC searches.
 type By int
 
 const (
@@ -34,6 +26,7 @@ const (
 	MakeDepends
 	OptDepends
 	CheckDepends
+	None
 )
 
 func (by By) String() string {
@@ -52,37 +45,11 @@ func (by By) String() string {
 		return "optdepends"
 	case CheckDepends:
 		return "checkdepends"
+	case None:
+		return ""
 	default:
 		panic("invalid By")
 	}
-}
-
-// Pkg holds package information
-type Pkg struct {
-	ID             int      `json:"ID"`
-	Name           string   `json:"Name"`
-	PackageBaseID  int      `json:"PackageBaseID"`
-	PackageBase    string   `json:"PackageBase"`
-	Version        string   `json:"Version"`
-	Description    string   `json:"Description"`
-	URL            string   `json:"URL"`
-	NumVotes       int      `json:"NumVotes"`
-	Popularity     float64  `json:"Popularity"`
-	OutOfDate      int      `json:"OutOfDate"`
-	Maintainer     string   `json:"Maintainer"`
-	FirstSubmitted int      `json:"FirstSubmitted"`
-	LastModified   int      `json:"LastModified"`
-	URLPath        string   `json:"URLPath"`
-	Depends        []string `json:"Depends"`
-	MakeDepends    []string `json:"MakeDepends"`
-	CheckDepends   []string `json:"CheckDepends"`
-	Conflicts      []string `json:"Conflicts"`
-	Provides       []string `json:"Provides"`
-	Replaces       []string `json:"Replaces"`
-	OptDepends     []string `json:"OptDepends"`
-	Groups         []string `json:"Groups"`
-	License        []string `json:"License"`
-	Keywords       []string `json:"Keywords"`
 }
 
 func get(values url.Values) ([]Pkg, error) {

--- a/aur.go
+++ b/aur.go
@@ -92,9 +92,7 @@ func searchBy(query, by string) ([]Pkg, error) {
 
 func getErrorByStatusCode(code int) error {
 	switch code {
-	case http.StatusBadGateway, http.StatusGatewayTimeout:
-		return ErrServiceUnavailable
-	case http.StatusServiceUnavailable:
+	case http.StatusBadGateway, http.StatusGatewayTimeout, http.StatusServiceUnavailable:
 		return ErrServiceUnavailable
 	}
 	return nil

--- a/aur_test.go
+++ b/aur_test.go
@@ -104,7 +104,7 @@ func TestSearchPanic(t *testing.T) {
 
 // TestSearchByDepends test searching for packages by depends
 func TestSearchByDepends(t *testing.T) {
-	rs, err := SearchBy("python", Depends)
+	rs, err := SearchBy("linux", Depends)
 	expectPackages(t, 100, rs, err)
 }
 

--- a/client.go
+++ b/client.go
@@ -1,0 +1,204 @@
+package aur
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type PayloadError struct {
+	StatusCode int
+	ErrorField string
+}
+
+func (r *PayloadError) Error() string {
+	return fmt.Sprintf("status %d: err %s", r.StatusCode, r.ErrorField)
+}
+
+const _defaultURL = "https://aur.archlinux.org/rpc.php?"
+
+// The interface specification for the client above.
+type ClientInterface interface {
+	// Search queries the AUR DB with an optional By filter.
+	// Use By.None for default query param (name-desc)
+	Search(ctx context.Context, query string, by By, reqEditors ...RequestEditorFn) ([]Pkg, error)
+
+	// Info gives detailed information on existing package.
+	Info(ctx context.Context, pkgs []string, reqEditors ...RequestEditorFn) ([]Pkg, error)
+}
+
+// Client for AUR searching and querying.
+type Client struct {
+	baseURL string
+
+	// Doer for performing requests, typically a *http.Client with any
+	// customized settings, such as certificate chains.
+	HTTPClient HTTPRequestDoer
+
+	// A list of callbacks for modifying requests which are generated before sending over
+	// the network.
+	RequestEditors []RequestEditorFn
+}
+
+// ClientOption allows setting custom parameters during construction.
+type ClientOption func(*Client) error
+
+// Doer performs HTTP requests.
+//
+// The standard http.Client implements this interface.
+type HTTPRequestDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// RequestEditorFn  is the function signature for the RequestEditor callback function.
+type RequestEditorFn func(ctx context.Context, req *http.Request) error
+
+func NewClient(opts ...ClientOption) (*Client, error) {
+	client := Client{
+		baseURL:        "",
+		HTTPClient:     nil,
+		RequestEditors: []RequestEditorFn{},
+	}
+
+	// mutate client and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+
+	// create httpClient, if not already present
+	if client.HTTPClient == nil {
+		client.HTTPClient = http.DefaultClient
+	}
+
+	// set default baseURL if not present or valid
+	if client.baseURL == "" {
+		client.baseURL = _defaultURL
+	}
+
+	// ensure the server URL always has a trailing slash
+	if !strings.HasSuffix(client.baseURL, "/") {
+		client.baseURL += "/"
+	}
+
+	return &client, nil
+}
+
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+func WithHTTPClient(doer HTTPRequestDoer) ClientOption {
+	return func(c *Client) error {
+		c.HTTPClient = doer
+
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
+	return func(c *Client) error {
+		c.RequestEditors = append(c.RequestEditors, fn)
+
+		return nil
+	}
+}
+
+func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
+	for _, r := range c.RequestEditors {
+		if err := r(ctx, req); err != nil {
+			return err
+		}
+	}
+
+	for _, r := range additionalEditors {
+		if err := r(ctx, req); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func newAURRPCRequest(baseURL string, values url.Values) (*http.Request, error) {
+	values.Set("v", "5")
+
+	req, err := http.NewRequest("GET", baseURL+values.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	return req, nil
+}
+
+func parseRPCResponse(resp *http.Response) ([]Pkg, error) {
+	defer resp.Body.Close()
+
+	if err := getErrorByStatusCode(resp.StatusCode); err != nil {
+		return nil, err
+	}
+
+	result := new(response)
+
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return nil, fmt.Errorf("response decoding failed: %w", err)
+	}
+
+	if len(result.Error) > 0 {
+		return nil, &PayloadError{
+			StatusCode: resp.StatusCode,
+			ErrorField: result.Error,
+		}
+	}
+
+	return result.Results, nil
+}
+
+// Search queries the AUR DB with an optional By field.
+// Use By.None for default query param (name-desc)
+func (c *Client) Search(ctx context.Context, query string, by By, reqEditors ...RequestEditorFn) ([]Pkg, error) {
+	v := url.Values{}
+	v.Set("type", "search")
+	v.Set("arg", query)
+
+	if by != None {
+		v.Set("by", by.String())
+	}
+
+	return c.get(ctx, v, reqEditors)
+}
+
+// Info shows info for one or multiple packages.
+func (c *Client) Info(ctx context.Context, pkgs []string, reqEditors ...RequestEditorFn) ([]Pkg, error) {
+	v := url.Values{}
+	v.Set("type", "info")
+
+	for _, arg := range pkgs {
+		v.Add("arg[]", arg)
+	}
+
+	return c.get(ctx, v, reqEditors)
+}
+
+func (c *Client) get(ctx context.Context, values url.Values, reqEditors []RequestEditorFn) ([]Pkg, error) {
+	req, err := newAURRPCRequest(c.baseURL, values)
+	if err != nil {
+		return nil, err
+	}
+
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	return parseRPCResponse(resp)
+}

--- a/client.go
+++ b/client.go
@@ -32,7 +32,7 @@ type ClientInterface interface {
 
 // Client for AUR searching and querying.
 type Client struct {
-	baseURL string
+	BaseURL string
 
 	// Doer for performing requests, typically a *http.Client with any
 	// customized settings, such as certificate chains.
@@ -58,7 +58,7 @@ type RequestEditorFn func(ctx context.Context, req *http.Request) error
 
 func NewClient(opts ...ClientOption) (*Client, error) {
 	client := Client{
-		baseURL:        _defaultURL,
+		BaseURL:        _defaultURL,
 		HTTPClient:     nil,
 		RequestEditors: []RequestEditorFn{},
 	}
@@ -76,13 +76,13 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	}
 
 	// ensure base URL has /rpc.php?
-	if !strings.HasSuffix(client.baseURL, "rpc.php?") {
+	if !strings.HasSuffix(client.BaseURL, "rpc.php?") {
 		// ensure the server URL always has a trailing slash
-		if !strings.HasSuffix(client.baseURL, "/") {
-			client.baseURL += "/"
+		if !strings.HasSuffix(client.BaseURL, "/") {
+			client.BaseURL += "/"
 		}
 
-		client.baseURL += "rpc.php?"
+		client.BaseURL += "rpc.php?"
 	}
 
 	return &client, nil
@@ -101,7 +101,7 @@ func WithHTTPClient(doer HTTPRequestDoer) ClientOption {
 // WithBaseURL allows overriding the default base URL of the client,
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
-		c.baseURL = baseURL
+		c.BaseURL = baseURL
 
 		return nil
 	}
@@ -194,7 +194,7 @@ func (c *Client) Info(ctx context.Context, pkgs []string, reqEditors ...RequestE
 }
 
 func (c *Client) get(ctx context.Context, values url.Values, reqEditors []RequestEditorFn) ([]Pkg, error) {
-	req, err := newAURRPCRequest(ctx, c.baseURL, values)
+	req, err := newAURRPCRequest(ctx, c.BaseURL, values)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ type PayloadError struct {
 }
 
 func (r *PayloadError) Error() string {
-	return fmt.Sprintf("status %d: err %s", r.StatusCode, r.ErrorField)
+	return fmt.Sprintf("status %d: %s", r.StatusCode, r.ErrorField)
 }
 
 const _defaultURL = "https://aur.archlinux.org/rpc.php?"

--- a/client_test.go
+++ b/client_test.go
@@ -129,7 +129,7 @@ func TestNewClient(t *testing.T) {
 				t.Errorf("NewClient() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.Equal(t, tt.wantBaseURL, got.baseURL)
+			assert.Equal(t, tt.wantBaseURL, got.BaseURL)
 			assert.Equal(t, tt.wanthttpClient, got.HTTPClient)
 			assert.Equal(t, len(tt.wantRequestDoers), len(got.RequestEditors))
 		})
@@ -225,7 +225,7 @@ func TestClient_applyEditors_client(t *testing.T) {
 		return nil
 	}
 	c := &Client{
-		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		BaseURL:        "https://aur.archlinux.org/rpc.php?",
 		HTTPClient:     http.DefaultClient,
 		RequestEditors: []RequestEditorFn{requestEditor},
 	}
@@ -244,7 +244,7 @@ func TestClient_applyEditors_extra(t *testing.T) {
 		return nil
 	}
 	c := &Client{
-		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		BaseURL:        "https://aur.archlinux.org/rpc.php?",
 		HTTPClient:     http.DefaultClient,
 		RequestEditors: []RequestEditorFn{},
 	}
@@ -263,7 +263,7 @@ func TestClient_applyEditors_error(t *testing.T) {
 		return ErrServiceUnavailable
 	}
 	c := &Client{
-		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		BaseURL:        "https://aur.archlinux.org/rpc.php?",
 		HTTPClient:     http.DefaultClient,
 		RequestEditors: []RequestEditorFn{},
 	}
@@ -289,7 +289,7 @@ func TestClient_Search(t *testing.T) {
 	testClient := new(MockedClient)
 
 	c := &Client{
-		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		BaseURL:        "https://aur.archlinux.org/rpc.php?",
 		HTTPClient:     testClient,
 		RequestEditors: []RequestEditorFn{},
 	}
@@ -316,7 +316,7 @@ func TestClient_Info(t *testing.T) {
 	testClient := new(MockedClient)
 
 	c := &Client{
-		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		BaseURL:        "https://aur.archlinux.org/rpc.php?",
 		HTTPClient:     testClient,
 		RequestEditors: []RequestEditorFn{},
 	}
@@ -343,7 +343,7 @@ func TestClient_InfoNoMatch(t *testing.T) {
 	testClient := new(MockedClient)
 
 	c := &Client{
-		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		BaseURL:        "https://aur.archlinux.org/rpc.php?",
 		HTTPClient:     testClient,
 		RequestEditors: []RequestEditorFn{},
 	}
@@ -370,7 +370,7 @@ func TestClient_InfoError(t *testing.T) {
 	testClient := new(MockedClient)
 
 	c := &Client{
-		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		BaseURL:        "https://aur.archlinux.org/rpc.php?",
 		HTTPClient:     testClient,
 		RequestEditors: []RequestEditorFn{},
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,392 @@
+package aur
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const errorPayload = `{"version":5,"type":"error","resultcount":0,
+"results":[],"error":"Incorrect by field specified."}`
+
+const noMatchPayload = `{"version":5,"type":"error","resultcount":0,
+"results":[],"error":""}`
+
+const validPayload = `{
+    "version":5,
+    "type":"multiinfo",
+    "resultcount":1,
+    "results":[{
+        "ID":229417,
+        "Name":"cower",
+        "PackageBaseID":44921,
+        "PackageBase":"cower",
+        "Version":"14-2",
+        "Description":"A simple AUR agent with a pretentious name",
+        "URL":"http:\/\/github.com\/falconindy\/cower",
+        "NumVotes":590,
+        "Popularity":24.595536,
+        "OutOfDate":null,
+        "Maintainer":"falconindy",
+        "FirstSubmitted":1293676237,
+        "LastModified":1441804093,
+        "URLPath":"\/cgit\/aur.git\/snapshot\/cower.tar.gz",
+        "Depends":[
+            "curl",
+            "openssl",
+            "pacman",
+            "yajl"
+        ],
+        "MakeDepends":[
+            "perl"
+        ],
+        "License":[
+            "MIT"
+        ],
+        "Keywords":[]
+    }]
+ }
+`
+
+var validPayloadItems = []Pkg{{ID: 229417, Name: "cower", PackageBaseID: 44921,
+	PackageBase: "cower", Version: "14-2", Description: "A simple AUR agent with a pretentious name",
+	URL: "http://github.com/falconindy/cower", NumVotes: 590, Popularity: 24.595536, OutOfDate: 0,
+	Maintainer: "falconindy", FirstSubmitted: 1293676237, LastModified: 1441804093,
+	URLPath: "/cgit/aur.git/snapshot/cower.tar.gz", Depends: []string{"curl", "openssl", "pacman", "yajl"},
+	MakeDepends: []string{"perl"}, CheckDepends: []string(nil), Conflicts: []string(nil),
+	Provides: []string(nil), Replaces: []string(nil), OptDepends: []string(nil),
+	Groups: []string(nil), License: []string{"MIT"}, Keywords: []string{}}}
+
+func TestNewClient(t *testing.T) {
+	newHTTPClient := &http.Client{}
+
+	customRequestEditor := func(ctx context.Context, req *http.Request) error {
+		return nil
+	}
+
+	type args struct {
+		opts []ClientOption
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantBaseURL      string
+		wanthttpClient   *http.Client
+		wantRequestDoers []RequestEditorFn
+		wantErr          bool
+	}{
+		{
+			name:             "default",
+			args:             args{opts: []ClientOption{}},
+			wantBaseURL:      "https://aur.archlinux.org/rpc.php?",
+			wanthttpClient:   http.DefaultClient,
+			wantErr:          false,
+			wantRequestDoers: []RequestEditorFn{},
+		},
+		{
+			name:             "custom base url",
+			args:             args{opts: []ClientOption{WithBaseURL("localhost:8000")}},
+			wantBaseURL:      "localhost:8000/rpc.php?",
+			wanthttpClient:   http.DefaultClient,
+			wantErr:          false,
+			wantRequestDoers: []RequestEditorFn{},
+		},
+		{
+			name:             "custom base url complete",
+			args:             args{opts: []ClientOption{WithBaseURL("localhost:8000/rpc.php?")}},
+			wantBaseURL:      "localhost:8000/rpc.php?",
+			wanthttpClient:   http.DefaultClient,
+			wantErr:          false,
+			wantRequestDoers: []RequestEditorFn{},
+		},
+		{
+			name:             "custom http client",
+			args:             args{opts: []ClientOption{WithHTTPClient(newHTTPClient)}},
+			wantBaseURL:      "https://aur.archlinux.org/rpc.php?",
+			wanthttpClient:   newHTTPClient,
+			wantErr:          false,
+			wantRequestDoers: []RequestEditorFn{},
+		},
+		{
+			name:             "custom request editor",
+			args:             args{opts: []ClientOption{WithRequestEditorFn(customRequestEditor)}},
+			wantBaseURL:      "https://aur.archlinux.org/rpc.php?",
+			wanthttpClient:   newHTTPClient,
+			wantErr:          false,
+			wantRequestDoers: []RequestEditorFn{customRequestEditor},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewClient(tt.args.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.wantBaseURL, got.baseURL)
+			assert.Equal(t, tt.wanthttpClient, got.HTTPClient)
+			assert.Equal(t, len(tt.wantRequestDoers), len(got.RequestEditors))
+		})
+	}
+}
+
+func Test_newAURRPCRequest(t *testing.T) {
+	values := url.Values{}
+	values.Set("type", "search")
+	values.Set("arg", "test-query")
+	got, err := newAURRPCRequest(context.Background(), _defaultURL, values)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://aur.archlinux.org/rpc.php?arg=test-query&type=search&v=5", got.URL.String())
+}
+
+func Test_parseRPCResponse(t *testing.T) {
+	type args struct {
+		resp *http.Response
+	}
+	tests := []struct {
+		name       string
+		args       args
+		want       []Pkg
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "service unavailable",
+			args: args{resp: &http.Response{
+				StatusCode: 503,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("{}"))}},
+			want:       []Pkg{},
+			wantErr:    true,
+			wantErrMsg: "AUR is unavailable at this moment",
+		},
+		{
+			name: "ok empty body",
+			args: args{resp: &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("{}"))}},
+			want:       nil,
+			wantErr:    false,
+			wantErrMsg: "",
+		},
+		{
+			name: "ok empty body",
+			args: args{resp: &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("{}"))}},
+			want:       nil,
+			wantErr:    false,
+			wantErrMsg: "",
+		},
+		{
+			name: "payload error",
+			args: args{resp: &http.Response{
+				StatusCode: 400,
+				Body:       ioutil.NopCloser(bytes.NewBufferString(errorPayload))}},
+			want:       nil,
+			wantErr:    true,
+			wantErrMsg: "status 400: Incorrect by field specified.",
+		},
+		{
+			name: "valid payload",
+			args: args{resp: &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(bytes.NewBufferString(validPayload))}},
+			want:       validPayloadItems,
+			wantErr:    false,
+			wantErrMsg: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRPCResponse(tt.args.resp)
+
+			if tt.wantErr {
+				assert.EqualError(t, err, tt.wantErrMsg)
+
+				return
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}
+
+func TestClient_applyEditors_client(t *testing.T) {
+	requestEditor := func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("test", "value-test")
+		return nil
+	}
+	c := &Client{
+		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		HTTPClient:     http.DefaultClient,
+		RequestEditors: []RequestEditorFn{requestEditor},
+	}
+
+	req := &http.Request{Header: http.Header{}}
+
+	err := c.applyEditors(context.Background(), req, []RequestEditorFn{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "value-test", req.Header.Get("test"))
+}
+
+func TestClient_applyEditors_extra(t *testing.T) {
+	requestEditor := func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("test", "value-test")
+		return nil
+	}
+	c := &Client{
+		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		HTTPClient:     http.DefaultClient,
+		RequestEditors: []RequestEditorFn{},
+	}
+
+	req := &http.Request{Header: http.Header{}}
+
+	err := c.applyEditors(context.Background(), req, []RequestEditorFn{requestEditor})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "value-test", req.Header.Get("test"))
+}
+
+func TestClient_applyEditors_error(t *testing.T) {
+	requestEditor := func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("test", "value-test")
+		return ErrServiceUnavailable
+	}
+	c := &Client{
+		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		HTTPClient:     http.DefaultClient,
+		RequestEditors: []RequestEditorFn{},
+	}
+
+	req := &http.Request{Header: http.Header{}}
+
+	err := c.applyEditors(context.Background(), req, []RequestEditorFn{requestEditor})
+	assert.Error(t, err)
+}
+
+type MockedClient struct {
+	mock.Mock
+}
+
+func (m *MockedClient) Do(req *http.Request) (*http.Response, error) {
+	args := m.Called(req)
+
+	return args.Get(0).(*http.Response), args.Error(1)
+
+}
+
+func TestClient_Search(t *testing.T) {
+	testClient := new(MockedClient)
+
+	c := &Client{
+		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		HTTPClient:     testClient,
+		RequestEditors: []RequestEditorFn{},
+	}
+
+	testClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(validPayload))}, nil)
+
+	got, err := c.Search(context.Background(), "test", Name)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, validPayloadItems, got)
+
+	testClient.AssertNumberOfCalls(t, "Do", 1)
+	testClient.AssertExpectations(t)
+
+	requestMade := testClient.Calls[0].Arguments.Get(0).(*http.Request)
+	assert.Equal(t, "https://aur.archlinux.org/rpc.php?arg=test&by=name&type=search&v=5",
+		requestMade.URL.String())
+}
+
+func TestClient_Info(t *testing.T) {
+	testClient := new(MockedClient)
+
+	c := &Client{
+		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		HTTPClient:     testClient,
+		RequestEditors: []RequestEditorFn{},
+	}
+
+	testClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(validPayload))}, nil)
+
+	got, err := c.Info(context.Background(), []string{"test"})
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, validPayloadItems, got)
+
+	testClient.AssertNumberOfCalls(t, "Do", 1)
+	testClient.AssertExpectations(t)
+
+	requestMade := testClient.Calls[0].Arguments.Get(0).(*http.Request)
+	assert.Equal(t, "https://aur.archlinux.org/rpc.php?arg%5B%5D=test&type=info&v=5",
+		requestMade.URL.String())
+}
+
+func TestClient_InfoNoMatch(t *testing.T) {
+	testClient := new(MockedClient)
+
+	c := &Client{
+		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		HTTPClient:     testClient,
+		RequestEditors: []RequestEditorFn{},
+	}
+
+	testClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(noMatchPayload))}, nil)
+
+	got, err := c.Info(context.Background(), []string{"test"})
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, []Pkg{}, got)
+
+	testClient.AssertNumberOfCalls(t, "Do", 1)
+	testClient.AssertExpectations(t)
+
+	requestMade := testClient.Calls[0].Arguments.Get(0).(*http.Request)
+	assert.Equal(t, "https://aur.archlinux.org/rpc.php?arg%5B%5D=test&type=info&v=5",
+		requestMade.URL.String())
+}
+
+func TestClient_InfoError(t *testing.T) {
+	testClient := new(MockedClient)
+
+	c := &Client{
+		baseURL:        "https://aur.archlinux.org/rpc.php?",
+		HTTPClient:     testClient,
+		RequestEditors: []RequestEditorFn{},
+	}
+
+	testClient.On("Do", mock.Anything).Return(&http.Response{
+		StatusCode: 503,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(errorPayload))}, nil)
+
+	_, err := c.Info(context.Background(), []string{"test"})
+
+	assert.ErrorIs(t, ErrServiceUnavailable, err)
+
+	testClient.AssertNumberOfCalls(t, "Do", 1)
+	testClient.AssertExpectations(t)
+
+	requestMade := testClient.Calls[0].Arguments.Get(0).(*http.Request)
+	assert.Equal(t, "https://aur.archlinux.org/rpc.php?arg%5B%5D=test&type=info&v=5",
+		requestMade.URL.String())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/mikkeloscar/aur
 
 go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/types.go
+++ b/types.go
@@ -1,0 +1,37 @@
+package aur
+
+type response struct {
+	Error       string `json:"error"`
+	Type        string `json:"type"`
+	Version     int    `json:"version"`
+	ResultCount int    `json:"resultcount"`
+	Results     []Pkg  `json:"results"`
+}
+
+// Pkg holds package information
+type Pkg struct {
+	ID             int      `json:"ID"`
+	Name           string   `json:"Name"`
+	PackageBaseID  int      `json:"PackageBaseID"`
+	PackageBase    string   `json:"PackageBase"`
+	Version        string   `json:"Version"`
+	Description    string   `json:"Description"`
+	URL            string   `json:"URL"`
+	NumVotes       int      `json:"NumVotes"`
+	Popularity     float64  `json:"Popularity"`
+	OutOfDate      int      `json:"OutOfDate"`
+	Maintainer     string   `json:"Maintainer"`
+	FirstSubmitted int      `json:"FirstSubmitted"`
+	LastModified   int      `json:"LastModified"`
+	URLPath        string   `json:"URLPath"`
+	Depends        []string `json:"Depends"`
+	MakeDepends    []string `json:"MakeDepends"`
+	CheckDepends   []string `json:"CheckDepends"`
+	Conflicts      []string `json:"Conflicts"`
+	Provides       []string `json:"Provides"`
+	Replaces       []string `json:"Replaces"`
+	OptDepends     []string `json:"OptDepends"`
+	Groups         []string `json:"Groups"`
+	License        []string `json:"License"`
+	Keywords       []string `json:"Keywords"`
+}


### PR DESCRIPTION
Hey @mikkeloscar , following https://github.com/Jguer/yay/issues/1498 I wanted to implement this functionality on the AUR wrapper.

I ended up updating it to a more convenient format (for me personally) with context usage and request editing to add the custom user agent or other settings (This will be useful for proxy/CA settings...).

I've also ported the new tests to not depend on network conditions

I've left the rest of the code if you want keep retro-compatibility for now.

Please tell me if it's of any interest to you 

