### PR TITLE
Add support for searching by co-maintainer

### DIFF
--- a/aur.go
+++ b/aur.go
@@ -7,13 +7,11 @@ import (
 	"net/url"
 )
 
-//AURURL is the base string from which the query is built
+// AURURL is the base string from which the query is built
 var AURURL = "https://aur.archlinux.org/rpc.php?"
 
-var (
-	// ErrServiceUnavailable represents a error when AUR is unavailable
-	ErrServiceUnavailable = errors.New("AUR is unavailable at this moment")
-)
+// ErrServiceUnavailable represents a error when AUR is unavailable
+var ErrServiceUnavailable = errors.New("AUR is unavailable at this moment")
 
 type response struct {
 	Error       string `json:"error"`
@@ -23,13 +21,14 @@ type response struct {
 	Results     []Pkg  `json:"results"`
 }
 
-//By specifies what to seach by in RPC searches
+// By specifies what to seach by in RPC searches
 type By int
 
 const (
 	Name By = iota + 1
 	NameDesc
 	Maintainer
+	CoMaintainers
 	Depends
 	MakeDepends
 	OptDepends
@@ -44,6 +43,8 @@ func (by By) String() string {
 		return "name-desc"
 	case Maintainer:
 		return "maintainer"
+	case CoMaintainers:
+		return "comaintainers"
 	case Depends:
 		return "depends"
 	case MakeDepends:
@@ -83,6 +84,7 @@ type Pkg struct {
 	Groups         []string `json:"Groups"`
 	License        []string `json:"License"`
 	Keywords       []string `json:"Keywords"`
+	CoMaintainers  []string `json:"CoMaintainers"`
 }
 
 func get(values url.Values) ([]Pkg, error) {


### PR DESCRIPTION
This adds support for searching by co-maintainers, and includes a list of co-maintainers when fetching package information as per the RPC schema `PackageDetailed`[0].

I have not added any test cases, since the existing tests are broken anyway due to making actual RPC calls to the API and relying on static values in the test cases that does not match the current state of the matching packages that are queried.

I am planning to contribute a refactoring of the test suite that will use mock responses instead, and not depend on the live RPC API for running tests. This will be submitted as a separate PR.


[0] https://aur.archlinux.org/rpc/swagger